### PR TITLE
Fix Reference Error: __dirname is not defined

### DIFF
--- a/dist/package.json
+++ b/dist/package.json
@@ -1,3 +1,0 @@
-{
-  "type": "module"
-}


### PR DESCRIPTION
Fixes:
`ReferenceError: __dirname is not defined in ES module scope`

Changes:
- Remove package.json containing type module