### PR TITLE
Avoid updating previous check runs

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -1,7 +1,7 @@
 /******/ (() => { // webpackBootstrap
 /******/ 	var __webpack_modules__ = ({
 
-/***/ 80:
+/***/ 914:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -14,8 +14,8 @@ var __importStar = (this && this.__importStar) || function (mod) {
     return result;
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-const os = __importStar(__nccwpck_require__(87));
-const utils_1 = __nccwpck_require__(160);
+const os = __importStar(__nccwpck_require__(857));
+const utils_1 = __nccwpck_require__(302);
 /**
  * Commands
  *
@@ -87,7 +87,7 @@ function escapeProperty(s) {
 
 /***/ }),
 
-/***/ 728:
+/***/ 484:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -109,11 +109,11 @@ var __importStar = (this && this.__importStar) || function (mod) {
     return result;
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-const command_1 = __nccwpck_require__(80);
-const file_command_1 = __nccwpck_require__(371);
-const utils_1 = __nccwpck_require__(160);
-const os = __importStar(__nccwpck_require__(87));
-const path = __importStar(__nccwpck_require__(622));
+const command_1 = __nccwpck_require__(914);
+const file_command_1 = __nccwpck_require__(753);
+const utils_1 = __nccwpck_require__(302);
+const os = __importStar(__nccwpck_require__(857));
+const path = __importStar(__nccwpck_require__(928));
 /**
  * The code to exit an action
  */
@@ -332,7 +332,7 @@ exports.getState = getState;
 
 /***/ }),
 
-/***/ 371:
+/***/ 753:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -348,9 +348,9 @@ var __importStar = (this && this.__importStar) || function (mod) {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 // We use any as a valid input type
 /* eslint-disable @typescript-eslint/no-explicit-any */
-const fs = __importStar(__nccwpck_require__(747));
-const os = __importStar(__nccwpck_require__(87));
-const utils_1 = __nccwpck_require__(160);
+const fs = __importStar(__nccwpck_require__(896));
+const os = __importStar(__nccwpck_require__(857));
+const utils_1 = __nccwpck_require__(302);
 function issueCommand(command, message) {
     const filePath = process.env[`GITHUB_${command}`];
     if (!filePath) {
@@ -368,7 +368,7 @@ exports.issueCommand = issueCommand;
 
 /***/ }),
 
-/***/ 160:
+/***/ 302:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -394,15 +394,15 @@ exports.toCommandValue = toCommandValue;
 
 /***/ }),
 
-/***/ 701:
+/***/ 648:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.Context = void 0;
-const fs_1 = __nccwpck_require__(747);
-const os_1 = __nccwpck_require__(87);
+const fs_1 = __nccwpck_require__(896);
+const os_1 = __nccwpck_require__(857);
 class Context {
     /**
      * Hydrate the context from the environment
@@ -451,7 +451,7 @@ exports.Context = Context;
 
 /***/ }),
 
-/***/ 482:
+/***/ 228:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -477,8 +477,8 @@ var __importStar = (this && this.__importStar) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getOctokit = exports.context = void 0;
-const Context = __importStar(__nccwpck_require__(701));
-const utils_1 = __nccwpck_require__(774);
+const Context = __importStar(__nccwpck_require__(648));
+const utils_1 = __nccwpck_require__(6);
 exports.context = new Context.Context();
 /**
  * Returns a hydrated octokit ready to use for GitHub Actions
@@ -494,7 +494,7 @@ exports.getOctokit = getOctokit;
 
 /***/ }),
 
-/***/ 513:
+/***/ 156:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -520,7 +520,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getApiBaseUrl = exports.getProxyAgent = exports.getAuthString = void 0;
-const httpClient = __importStar(__nccwpck_require__(58));
+const httpClient = __importStar(__nccwpck_require__(192));
 function getAuthString(token, options) {
     if (!token && !options.auth) {
         throw new Error('Parameter token or opts.auth is required');
@@ -544,7 +544,7 @@ exports.getApiBaseUrl = getApiBaseUrl;
 
 /***/ }),
 
-/***/ 774:
+/***/ 6:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -570,12 +570,12 @@ var __importStar = (this && this.__importStar) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getOctokitOptions = exports.GitHub = exports.context = void 0;
-const Context = __importStar(__nccwpck_require__(701));
-const Utils = __importStar(__nccwpck_require__(513));
+const Context = __importStar(__nccwpck_require__(648));
+const Utils = __importStar(__nccwpck_require__(156));
 // octokit + plugins
-const core_1 = __nccwpck_require__(827);
-const plugin_rest_endpoint_methods_1 = __nccwpck_require__(207);
-const plugin_paginate_rest_1 = __nccwpck_require__(939);
+const core_1 = __nccwpck_require__(897);
+const plugin_rest_endpoint_methods_1 = __nccwpck_require__(935);
+const plugin_paginate_rest_1 = __nccwpck_require__(82);
 exports.context = new Context.Context();
 const baseUrl = Utils.getApiBaseUrl();
 const defaults = {
@@ -605,15 +605,15 @@ exports.getOctokitOptions = getOctokitOptions;
 
 /***/ }),
 
-/***/ 58:
+/***/ 192:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-const http = __nccwpck_require__(605);
-const https = __nccwpck_require__(211);
-const pm = __nccwpck_require__(823);
+const http = __nccwpck_require__(611);
+const https = __nccwpck_require__(692);
+const pm = __nccwpck_require__(624);
 let tunnel;
 var HttpCodes;
 (function (HttpCodes) {
@@ -1032,7 +1032,7 @@ class HttpClient {
         if (useProxy) {
             // If using proxy, need tunnel
             if (!tunnel) {
-                tunnel = __nccwpck_require__(736);
+                tunnel = __nccwpck_require__(770);
             }
             const agentOptions = {
                 maxSockets: maxSockets,
@@ -1148,7 +1148,7 @@ exports.HttpClient = HttpClient;
 
 /***/ }),
 
-/***/ 823:
+/***/ 624:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -1213,7 +1213,7 @@ exports.checkBypass = checkBypass;
 
 /***/ }),
 
-/***/ 626:
+/***/ 864:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -1270,7 +1270,7 @@ exports.createTokenAuth = createTokenAuth;
 
 /***/ }),
 
-/***/ 827:
+/***/ 897:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -1278,11 +1278,11 @@ exports.createTokenAuth = createTokenAuth;
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 
-var universalUserAgent = __nccwpck_require__(514);
-var beforeAfterHook = __nccwpck_require__(930);
-var request = __nccwpck_require__(210);
-var graphql = __nccwpck_require__(789);
-var authToken = __nccwpck_require__(626);
+var universalUserAgent = __nccwpck_require__(843);
+var beforeAfterHook = __nccwpck_require__(732);
+var request = __nccwpck_require__(255);
+var graphql = __nccwpck_require__(7);
+var authToken = __nccwpck_require__(864);
 
 function _objectWithoutPropertiesLoose(source, excluded) {
   if (source == null) return {};
@@ -1452,7 +1452,7 @@ exports.Octokit = Octokit;
 
 /***/ }),
 
-/***/ 63:
+/***/ 471:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -1460,8 +1460,8 @@ exports.Octokit = Octokit;
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 
-var isPlainObject = __nccwpck_require__(88);
-var universalUserAgent = __nccwpck_require__(514);
+var isPlainObject = __nccwpck_require__(407);
+var universalUserAgent = __nccwpck_require__(843);
 
 function lowercaseKeys(object) {
   if (!object) {
@@ -1850,7 +1850,7 @@ exports.endpoint = endpoint;
 
 /***/ }),
 
-/***/ 789:
+/***/ 7:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -1858,8 +1858,8 @@ exports.endpoint = endpoint;
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 
-var request = __nccwpck_require__(210);
-var universalUserAgent = __nccwpck_require__(514);
+var request = __nccwpck_require__(255);
+var universalUserAgent = __nccwpck_require__(843);
 
 const VERSION = "4.5.8";
 
@@ -1966,7 +1966,7 @@ exports.withCustomRequest = withCustomRequest;
 
 /***/ }),
 
-/***/ 939:
+/***/ 82:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -2106,7 +2106,7 @@ exports.paginateRest = paginateRest;
 
 /***/ }),
 
-/***/ 207:
+/***/ 935:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -3247,7 +3247,7 @@ exports.restEndpointMethods = restEndpointMethods;
 
 /***/ }),
 
-/***/ 196:
+/***/ 708:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -3257,8 +3257,8 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 
 function _interopDefault (ex) { return (ex && (typeof ex === 'object') && 'default' in ex) ? ex['default'] : ex; }
 
-var deprecation = __nccwpck_require__(473);
-var once = _interopDefault(__nccwpck_require__(94));
+var deprecation = __nccwpck_require__(150);
+var once = _interopDefault(__nccwpck_require__(560));
 
 const logOnce = once(deprecation => console.warn(deprecation));
 /**
@@ -3310,7 +3310,7 @@ exports.RequestError = RequestError;
 
 /***/ }),
 
-/***/ 210:
+/***/ 255:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -3320,11 +3320,11 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 
 function _interopDefault (ex) { return (ex && (typeof ex === 'object') && 'default' in ex) ? ex['default'] : ex; }
 
-var endpoint = __nccwpck_require__(63);
-var universalUserAgent = __nccwpck_require__(514);
-var isPlainObject = __nccwpck_require__(88);
-var nodeFetch = _interopDefault(__nccwpck_require__(62));
-var requestError = __nccwpck_require__(196);
+var endpoint = __nccwpck_require__(471);
+var universalUserAgent = __nccwpck_require__(843);
+var isPlainObject = __nccwpck_require__(407);
+var nodeFetch = _interopDefault(__nccwpck_require__(705));
+var requestError = __nccwpck_require__(708);
 
 const VERSION = "5.4.12";
 
@@ -3466,12 +3466,12 @@ exports.request = request;
 
 /***/ }),
 
-/***/ 930:
+/***/ 732:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var register = __nccwpck_require__(763)
-var addHook = __nccwpck_require__(65)
-var removeHook = __nccwpck_require__(663)
+var register = __nccwpck_require__(63)
+var addHook = __nccwpck_require__(27)
+var removeHook = __nccwpck_require__(934)
 
 // bind with array of arguments: https://stackoverflow.com/a/21792913
 var bind = Function.bind
@@ -3530,7 +3530,7 @@ module.exports.Collection = Hook.Collection
 
 /***/ }),
 
-/***/ 65:
+/***/ 27:
 /***/ ((module) => {
 
 module.exports = addHook
@@ -3583,7 +3583,7 @@ function addHook (state, kind, name, hook) {
 
 /***/ }),
 
-/***/ 763:
+/***/ 63:
 /***/ ((module) => {
 
 module.exports = register
@@ -3618,7 +3618,7 @@ function register (state, name, method, options) {
 
 /***/ }),
 
-/***/ 663:
+/***/ 934:
 /***/ ((module) => {
 
 module.exports = removeHook
@@ -3642,7 +3642,7 @@ function removeHook (state, name, method) {
 
 /***/ }),
 
-/***/ 473:
+/***/ 150:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -3670,7 +3670,7 @@ exports.Deprecation = Deprecation;
 
 /***/ }),
 
-/***/ 88:
+/***/ 407:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -3716,7 +3716,7 @@ exports.isPlainObject = isPlainObject;
 
 /***/ }),
 
-/***/ 62:
+/***/ 705:
 /***/ ((module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -3726,11 +3726,11 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 
 function _interopDefault (ex) { return (ex && (typeof ex === 'object') && 'default' in ex) ? ex['default'] : ex; }
 
-var Stream = _interopDefault(__nccwpck_require__(413));
-var http = _interopDefault(__nccwpck_require__(605));
-var Url = _interopDefault(__nccwpck_require__(835));
-var https = _interopDefault(__nccwpck_require__(211));
-var zlib = _interopDefault(__nccwpck_require__(761));
+var Stream = _interopDefault(__nccwpck_require__(203));
+var http = _interopDefault(__nccwpck_require__(611));
+var Url = _interopDefault(__nccwpck_require__(16));
+var https = _interopDefault(__nccwpck_require__(692));
+var zlib = _interopDefault(__nccwpck_require__(106));
 
 // Based on https://github.com/tmpvar/jsdom/blob/aa85b2abf07766ff7bf5c1f6daafb3726f2f2db5/lib/jsdom/living/blob.js
 
@@ -3881,7 +3881,7 @@ FetchError.prototype.name = 'FetchError';
 
 let convert;
 try {
-	convert = __nccwpck_require__(508).convert;
+	convert = (__nccwpck_require__(78).convert);
 } catch (e) {}
 
 const INTERNALS = Symbol('Body internals');
@@ -5364,7 +5364,7 @@ fetch.Promise = global.Promise;
 
 module.exports = exports = fetch;
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.default = exports;
+exports["default"] = exports;
 exports.Headers = Headers;
 exports.Request = Request;
 exports.Response = Response;
@@ -5373,10 +5373,10 @@ exports.FetchError = FetchError;
 
 /***/ }),
 
-/***/ 94:
+/***/ 560:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var wrappy = __nccwpck_require__(639)
+var wrappy = __nccwpck_require__(264)
 module.exports = wrappy(once)
 module.exports.strict = wrappy(onceStrict)
 
@@ -5422,27 +5422,27 @@ function onceStrict (fn) {
 
 /***/ }),
 
-/***/ 736:
+/***/ 770:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-module.exports = __nccwpck_require__(222);
+module.exports = __nccwpck_require__(218);
 
 
 /***/ }),
 
-/***/ 222:
+/***/ 218:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-var net = __nccwpck_require__(631);
-var tls = __nccwpck_require__(16);
-var http = __nccwpck_require__(605);
-var https = __nccwpck_require__(211);
-var events = __nccwpck_require__(614);
-var assert = __nccwpck_require__(357);
-var util = __nccwpck_require__(669);
+var net = __nccwpck_require__(278);
+var tls = __nccwpck_require__(756);
+var http = __nccwpck_require__(611);
+var https = __nccwpck_require__(692);
+var events = __nccwpck_require__(434);
+var assert = __nccwpck_require__(613);
+var util = __nccwpck_require__(23);
 
 
 exports.httpOverHttp = httpOverHttp;
@@ -5702,7 +5702,7 @@ exports.debug = debug; // for test
 
 /***/ }),
 
-/***/ 514:
+/***/ 843:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -5728,7 +5728,7 @@ exports.getUserAgent = getUserAgent;
 
 /***/ }),
 
-/***/ 639:
+/***/ 264:
 /***/ ((module) => {
 
 // Returns a wrapper function that returns a wrapped callback
@@ -5768,7 +5768,7 @@ function wrappy (fn, cb) {
 
 /***/ }),
 
-/***/ 828:
+/***/ 561:
 /***/ ((__unused_webpack_module, exports) => {
 
 function parseInputTags (inputText) {
@@ -5786,7 +5786,7 @@ exports.parseInputTags = parseInputTags
 
 /***/ }),
 
-/***/ 508:
+/***/ 78:
 /***/ ((module) => {
 
 module.exports = eval("require")("encoding");
@@ -5794,7 +5794,7 @@ module.exports = eval("require")("encoding");
 
 /***/ }),
 
-/***/ 357:
+/***/ 613:
 /***/ ((module) => {
 
 "use strict";
@@ -5802,7 +5802,7 @@ module.exports = require("assert");
 
 /***/ }),
 
-/***/ 614:
+/***/ 434:
 /***/ ((module) => {
 
 "use strict";
@@ -5810,7 +5810,7 @@ module.exports = require("events");
 
 /***/ }),
 
-/***/ 747:
+/***/ 896:
 /***/ ((module) => {
 
 "use strict";
@@ -5818,7 +5818,7 @@ module.exports = require("fs");
 
 /***/ }),
 
-/***/ 605:
+/***/ 611:
 /***/ ((module) => {
 
 "use strict";
@@ -5826,7 +5826,7 @@ module.exports = require("http");
 
 /***/ }),
 
-/***/ 211:
+/***/ 692:
 /***/ ((module) => {
 
 "use strict";
@@ -5834,7 +5834,7 @@ module.exports = require("https");
 
 /***/ }),
 
-/***/ 631:
+/***/ 278:
 /***/ ((module) => {
 
 "use strict";
@@ -5842,7 +5842,7 @@ module.exports = require("net");
 
 /***/ }),
 
-/***/ 87:
+/***/ 857:
 /***/ ((module) => {
 
 "use strict";
@@ -5850,7 +5850,7 @@ module.exports = require("os");
 
 /***/ }),
 
-/***/ 622:
+/***/ 928:
 /***/ ((module) => {
 
 "use strict";
@@ -5858,7 +5858,7 @@ module.exports = require("path");
 
 /***/ }),
 
-/***/ 413:
+/***/ 203:
 /***/ ((module) => {
 
 "use strict";
@@ -5866,7 +5866,7 @@ module.exports = require("stream");
 
 /***/ }),
 
-/***/ 16:
+/***/ 756:
 /***/ ((module) => {
 
 "use strict";
@@ -5874,7 +5874,7 @@ module.exports = require("tls");
 
 /***/ }),
 
-/***/ 835:
+/***/ 16:
 /***/ ((module) => {
 
 "use strict";
@@ -5882,7 +5882,7 @@ module.exports = require("url");
 
 /***/ }),
 
-/***/ 669:
+/***/ 23:
 /***/ ((module) => {
 
 "use strict";
@@ -5890,7 +5890,7 @@ module.exports = require("util");
 
 /***/ }),
 
-/***/ 761:
+/***/ 106:
 /***/ ((module) => {
 
 "use strict";
@@ -5937,11 +5937,9 @@ module.exports = require("zlib");
 /******/ 	
 /************************************************************************/
 var __webpack_exports__ = {};
-// This entry need to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
-(() => {
-const core = __nccwpck_require__(728)
-const github = __nccwpck_require__(482)
-const { parseInputTags } = __nccwpck_require__(828)
+const core = __nccwpck_require__(484)
+const github = __nccwpck_require__(228)
+const { parseInputTags } = __nccwpck_require__(561)
 
 async function run() {
   try {
@@ -6013,42 +6011,9 @@ async function run() {
       )}`)
     }
 
-    const checks = await octokit.checks.listForRef({
-      ...context.repo,
-      ref: context.payload.pull_request.head.ref,
-    });
-
-    const checkRunIds = checks.data.check_runs.filter(check => check.name === context.job).map(check => check.id)
-
     if (failMessages.length) {
-      // update old checks
-      for (const id of checkRunIds) {
-        await octokit.checks.update({
-          ...context.repo,
-          check_run_id: id,
-          conclusion: 'failure',
-          output: {
-            title: 'Labels did not pass provided rules',
-            summary: failMessages.join('. ')
-          }
-        })
-      }
-
       core.setFailed(failMessages.join('. '))
     } else {
-      // update old checks
-      for (const id of checkRunIds) {
-        await octokit.checks.update({
-          ...context.repo,
-          check_run_id: id,
-          conclusion: 'success',
-          output: {
-            title: 'Labels follow all the provided rules',
-            summary: ''
-          }
-        })
-      }
-
       core.setOutput('passed', true)
     }
   } catch (error) {
@@ -6057,8 +6022,6 @@ async function run() {
 }
 
 run()
-
-})();
 
 module.exports = __webpack_exports__;
 /******/ })()

--- a/index.js
+++ b/index.js
@@ -72,42 +72,9 @@ async function run() {
       )}`)
     }
 
-    const checks = await octokit.checks.listForRef({
-      ...context.repo,
-      ref: context.payload.pull_request.head.ref,
-    });
-
-    const checkRunIds = checks.data.check_runs.filter(check => check.name === context.job).map(check => check.id)
-
     if (failMessages.length) {
-      // update old checks
-      for (const id of checkRunIds) {
-        await octokit.checks.update({
-          ...context.repo,
-          check_run_id: id,
-          conclusion: 'failure',
-          output: {
-            title: 'Labels did not pass provided rules',
-            summary: failMessages.join('. ')
-          }
-        })
-      }
-
       core.setFailed(failMessages.join('. '))
     } else {
-      // update old checks
-      for (const id of checkRunIds) {
-        await octokit.checks.update({
-          ...context.repo,
-          check_run_id: id,
-          conclusion: 'success',
-          output: {
-            title: 'Labels follow all the provided rules',
-            summary: ''
-          }
-        })
-      }
-
       core.setOutput('passed', true)
     }
   } catch (error) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,46 +1,59 @@
 {
   "name": "pr-labels-checker",
   "version": "2.0.0",
-  "lockfileVersion": 1,
+  "lockfileVersion": 3,
   "requires": true,
-  "dependencies": {
-    "@actions/core": {
+  "packages": {
+    "": {
+      "name": "pr-labels-checker",
+      "version": "2.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "@actions/core": "^1.2.6",
+        "@actions/github": "^4.0.0"
+      },
+      "devDependencies": {
+        "@vercel/ncc": "^0.38.3",
+        "ncc": "^0.3.6"
+      }
+    },
+    "node_modules/@actions/core": {
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.2.6.tgz",
       "integrity": "sha512-ZQYitnqiyBc3D+k7LsgSBmMDVkOVidaagDG7j3fOym77jNunWRuYx7VSHa9GNfFZh+zh61xsCjRj4JxMZlDqTA=="
     },
-    "@actions/github": {
+    "node_modules/@actions/github": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@actions/github/-/github-4.0.0.tgz",
       "integrity": "sha512-Ej/Y2E+VV6sR9X7pWL5F3VgEWrABaT292DRqRU6R4hnQjPtC/zD3nagxVdXWiRQvYDh8kHXo7IDmG42eJ/dOMA==",
-      "requires": {
+      "dependencies": {
         "@actions/http-client": "^1.0.8",
         "@octokit/core": "^3.0.0",
         "@octokit/plugin-paginate-rest": "^2.2.3",
         "@octokit/plugin-rest-endpoint-methods": "^4.0.0"
       }
     },
-    "@actions/http-client": {
+    "node_modules/@actions/http-client": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-1.0.9.tgz",
       "integrity": "sha512-0O4SsJ7q+MK0ycvXPl2e6bMXV7dxAXOGjrXS1eTF9s2S401Tp6c/P3c3Joz04QefC1J6Gt942Wl2jbm3f4mLcg==",
-      "requires": {
+      "dependencies": {
         "tunnel": "0.0.6"
       }
     },
-    "@octokit/auth-token": {
+    "node_modules/@octokit/auth-token": {
       "version": "2.4.4",
       "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-2.4.4.tgz",
       "integrity": "sha512-LNfGu3Ro9uFAYh10MUZVaT7X2CnNm2C8IDQmabx+3DygYIQjs9FwzFAHN/0t6mu5HEPhxcb1XOuxdpY82vCg2Q==",
-      "requires": {
+      "dependencies": {
         "@octokit/types": "^6.0.0"
       }
     },
-    "@octokit/core": {
+    "node_modules/@octokit/core": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/@octokit/core/-/core-3.2.4.tgz",
       "integrity": "sha512-d9dTsqdePBqOn7aGkyRFe7pQpCXdibSJ5SFnrTr0axevObZrpz3qkWm7t/NjYv5a66z6vhfteriaq4FRz3e0Qg==",
-      "requires": {
+      "dependencies": {
         "@octokit/auth-token": "^2.4.4",
         "@octokit/graphql": "^4.5.8",
         "@octokit/request": "^5.4.12",
@@ -49,53 +62,59 @@
         "universal-user-agent": "^6.0.0"
       }
     },
-    "@octokit/endpoint": {
+    "node_modules/@octokit/endpoint": {
       "version": "6.0.10",
       "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-6.0.10.tgz",
       "integrity": "sha512-9+Xef8nT7OKZglfkOMm7IL6VwxXUQyR7DUSU0LH/F7VNqs8vyd7es5pTfz9E7DwUIx7R3pGscxu1EBhYljyu7Q==",
-      "requires": {
+      "dependencies": {
         "@octokit/types": "^6.0.0",
         "is-plain-object": "^5.0.0",
         "universal-user-agent": "^6.0.0"
       }
     },
-    "@octokit/graphql": {
+    "node_modules/@octokit/graphql": {
       "version": "4.5.8",
       "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-4.5.8.tgz",
       "integrity": "sha512-WnCtNXWOrupfPJgXe+vSmprZJUr0VIu14G58PMlkWGj3cH+KLZEfKMmbUQ6C3Wwx6fdhzVW1CD5RTnBdUHxhhA==",
-      "requires": {
+      "dependencies": {
         "@octokit/request": "^5.3.0",
         "@octokit/types": "^6.0.0",
         "universal-user-agent": "^6.0.0"
       }
     },
-    "@octokit/openapi-types": {
+    "node_modules/@octokit/openapi-types": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-2.0.1.tgz",
       "integrity": "sha512-9AuC04PUnZrjoLiw3uPtwGh9FE4Q3rTqs51oNlQ0rkwgE8ftYsOC+lsrQyvCvWm85smBbSc0FNRKKumvGyb44Q=="
     },
-    "@octokit/plugin-paginate-rest": {
+    "node_modules/@octokit/plugin-paginate-rest": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.6.2.tgz",
       "integrity": "sha512-3Dy7/YZAwdOaRpGQoNHPeT0VU1fYLpIUdPyvR37IyFLgd6XSij4j9V/xN/+eSjF2KKvmfIulEh9LF1tRPjIiDA==",
-      "requires": {
+      "dependencies": {
         "@octokit/types": "^6.0.1"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=2"
       }
     },
-    "@octokit/plugin-rest-endpoint-methods": {
+    "node_modules/@octokit/plugin-rest-endpoint-methods": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-4.4.1.tgz",
       "integrity": "sha512-+v5PcvrUcDeFXf8hv1gnNvNLdm4C0+2EiuWt9EatjjUmfriM1pTMM+r4j1lLHxeBQ9bVDmbywb11e3KjuavieA==",
-      "requires": {
+      "dependencies": {
         "@octokit/types": "^6.1.0",
         "deprecation": "^2.3.1"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=3"
       }
     },
-    "@octokit/request": {
+    "node_modules/@octokit/request": {
       "version": "5.4.12",
       "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.4.12.tgz",
       "integrity": "sha512-MvWYdxengUWTGFpfpefBBpVmmEYfkwMoxonIB3sUGp5rhdgwjXL1ejo6JbgzG/QD9B/NYt/9cJX1pxXeSIUCkg==",
-      "requires": {
+      "dependencies": {
         "@octokit/endpoint": "^6.0.1",
         "@octokit/request-error": "^2.0.0",
         "@octokit/types": "^6.0.3",
@@ -106,230 +125,283 @@
         "universal-user-agent": "^6.0.0"
       }
     },
-    "@octokit/request-error": {
+    "node_modules/@octokit/request-error": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-2.0.4.tgz",
       "integrity": "sha512-LjkSiTbsxIErBiRh5wSZvpZqT4t0/c9+4dOe0PII+6jXR+oj/h66s7E4a/MghV7iT8W9ffoQ5Skoxzs96+gBPA==",
-      "requires": {
+      "dependencies": {
         "@octokit/types": "^6.0.0",
         "deprecation": "^2.0.0",
         "once": "^1.4.0"
       }
     },
-    "@octokit/types": {
+    "node_modules/@octokit/types": {
       "version": "6.1.2",
       "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.1.2.tgz",
       "integrity": "sha512-LPCpcLbcky7fWfHCTuc7tMiSHFpFlrThJqVdaHgowBTMS0ijlZFfonQC/C1PrZOjD4xRCYgBqH9yttEATGE/nw==",
-      "requires": {
+      "dependencies": {
         "@octokit/openapi-types": "^2.0.1",
         "@types/node": ">= 8"
       }
     },
-    "@types/node": {
+    "node_modules/@types/node": {
       "version": "14.14.19",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.19.tgz",
       "integrity": "sha512-4nhBPStMK04rruRVtVc6cDqhu7S9GZai0fpXgPXrFpcPX6Xul8xnrjSdGB4KPBVYG/R5+fXWdCM8qBoiULWGPQ=="
     },
-    "balanced-match": {
+    "node_modules/@vercel/ncc": {
+      "version": "0.38.3",
+      "resolved": "https://registry.npmjs.org/@vercel/ncc/-/ncc-0.38.3.tgz",
+      "integrity": "sha512-rnK6hJBS6mwc+Bkab+PGPs9OiS0i/3kdTO+CkI8V0/VrW3vmz7O2Pxjw/owOlmo6PKEIxRSeZKv/kuL9itnpYA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "ncc": "dist/ncc/cli.js"
+      }
+    },
+    "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
-    "before-after-hook": {
+    "node_modules/before-after-hook": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.1.0.tgz",
       "integrity": "sha512-IWIbu7pMqyw3EAJHzzHbWa85b6oud/yfKYg5rqB5hNE8CeMi3nX+2C2sj0HswfblST86hpVEOAb9x34NZd6P7A=="
     },
-    "brace-expansion": {
+    "node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
-    "colors": {
+    "node_modules/colors": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/colors/-/colors-1.2.3.tgz",
       "integrity": "sha512-qTfM2pNFeMZcLvf/RbrVAzDEVttZjFhaApfx9dplNjvHSX88Ui66zBRb/4YGob/xUWxDceirgoC1lT676asfCQ==",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=0.1.90"
+      }
     },
-    "concat-map": {
+    "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
-    "dateformat": {
+    "node_modules/dateformat": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
       "integrity": "sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
     },
-    "deprecation": {
+    "node_modules/deprecation": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
       "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ=="
     },
-    "fs.realpath": {
+    "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
-    "glob": {
+    "node_modules/glob": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
       "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
         "inherits": "2",
         "minimatch": "^3.0.4",
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "inflight": {
+    "node_modules/inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "once": "^1.3.0",
         "wrappy": "1"
       }
     },
-    "inherits": {
+    "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true
     },
-    "is-plain-object": {
+    "node_modules/is-plain-object": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
-      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q=="
+      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
-    "minimatch": {
+    "node_modules/minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
-    "minimist": {
+    "node_modules/minimist": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
       "dev": true
     },
-    "mkdirp": {
+    "node_modules/mkdirp": {
       "version": "0.5.5",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
       "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "minimist": "^1.2.5"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
       }
     },
-    "ncc": {
+    "node_modules/ncc": {
       "version": "0.3.6",
       "resolved": "https://registry.npmjs.org/ncc/-/ncc-0.3.6.tgz",
-      "integrity": "sha1-EbR6+XPX8jdK9GvA2FMzZqzJCOs=",
+      "integrity": "sha512-OXudTB2Ebt/FnOuDoPQbaa17+tdVqSOWA+gLfPxccWwsNED1uA2zEhpoB1hwdFC9yYbio/mdV5cvOtQI3Zrx1w==",
       "dev": true,
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "mkdirp": "^0.5.1",
         "rimraf": "^2.6.1",
         "tracer": "^0.8.7",
         "ws": "^2.3.1"
       }
     },
-    "node-fetch": {
+    "node_modules/node-fetch": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      }
     },
-    "once": {
+    "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "requires": {
+      "dependencies": {
         "wrappy": "1"
       }
     },
-    "path-is-absolute": {
+    "node_modules/path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
-    "rimraf": {
+    "node_modules/rimraf": {
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
       "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
       }
     },
-    "safe-buffer": {
+    "node_modules/safe-buffer": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
       "integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c=",
       "dev": true
     },
-    "tinytim": {
+    "node_modules/tinytim": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/tinytim/-/tinytim-0.1.1.tgz",
       "integrity": "sha1-yWih5VWa2VUyJO92J7qzTjyu+Kg=",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">= 0.2.0"
+      }
     },
-    "tracer": {
+    "node_modules/tracer": {
       "version": "0.8.15",
       "resolved": "https://registry.npmjs.org/tracer/-/tracer-0.8.15.tgz",
       "integrity": "sha512-ZQzlhd6zZFIpAhACiZkxLjl65XqVwi8t8UEBVGRIHAQN6nj55ftJWiFell+WSqWCP/vEycrIbUSuiyMwul+TFw==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "colors": "1.2.3",
         "dateformat": "3.0.3",
         "mkdirp": "^0.5.1",
         "tinytim": "0.1.1"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
       }
     },
-    "tunnel": {
+    "node_modules/tunnel": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
-      "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg=="
+      "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
+      "engines": {
+        "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
+      }
     },
-    "ultron": {
+    "node_modules/ultron": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
       "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og==",
       "dev": true
     },
-    "universal-user-agent": {
+    "node_modules/universal-user-agent": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.0.tgz",
       "integrity": "sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w=="
     },
-    "wrappy": {
+    "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
-    "ws": {
+    "node_modules/ws": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/ws/-/ws-2.3.1.tgz",
       "integrity": "sha1-a5Sz5EfLajY/eF6vlK9jWejoHIA=",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "safe-buffer": "~5.0.1",
         "ultron": "~1.1.0"
       }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "build": "ncc build index.js --license LICENSE"
+    "build": "npx ncc build index.js --license LICENSE"
   },
   "repository": {
     "type": "git",
@@ -28,6 +28,6 @@
     "@actions/github": "^4.0.0"
   },
   "devDependencies": {
-    "ncc": "^0.3.6"
+    "@vercel/ncc": "^0.38.3"
   }
 }


### PR DESCRIPTION
## Description

Github [no longer allows update](https://github.blog/changelog/2025-02-12-notice-of-upcoming-deprecations-and-breaking-changes-for-github-actions/#changes-to-check-run-status-modification) to previous check runs. Therefore, this operation can be removed since it is not necessary to update the old check runs.

## Changes
- Update ncc dev dependency
- Remove updating previous check runs